### PR TITLE
Update media archives description read me

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Kamiskaze was a Southern California ska band active in the 90s-2000s. I (Jason M
 
 The repository currently includes:
 - **Palm Springs w/ The Jawas** - Live performance recording -- December 13th 1996. 
+- **MP3 Folder** - Contains audio recordings from different sessions:
+  - The 8-track collection was recorded with a guy who had an audio 8-track player.
+  - The Cubase playlist was recorded with a different guy who had a more advanced Max setup in a studio in his garage.
+  - These descriptions are a rough idea of what the MP3s are, but the exact details are not fully remembered.
 - More to be added as materials are uncovered or submitted
 
 ## How to Access the Media


### PR DESCRIPTION
Fixes #5

Update `README.md` to include more details about the MP3 folder.

* Add a new section under "Media Archives" to describe the MP3 folder.
* Mention that the 8-track collection was recorded with a guy who had an audio 8-track player.
* Mention that the Cubase playlist was recorded with a different guy who had a more advanced Max setup in a studio in his garage.
* Indicate that the descriptions are a rough idea of what the MP3s are, but the exact details are not fully remembered.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jmcpheron/kamiskaze/pull/6?shareId=1e2bdd06-18ec-427b-8de2-4b818b38e7d6).